### PR TITLE
WIP Make all-cabal-hashes derivation reproducible

### DIFF
--- a/stackage2nix/lib.nix
+++ b/stackage2nix/lib.nix
@@ -1,4 +1,4 @@
-{ stdenv, cacert, git, curl
+{ stdenv, cacert, git, curl, perl
 , cacheVersion ? "0" }:
 
 {
@@ -20,13 +20,39 @@
 
   all-cabal-hashes = stdenv.mkDerivation rec {
     name = "all-cabal-hashes";
-    version = cacheVersion;
-    phases = [ "installPhase" ];
-    buildInputs = [ git ];
-    installPhase = ''
-      mkdir -p $out
-      git clone --branch hackage https://github.com/commercialhaskell/all-cabal-hashes.git $out
+
+    repo = "https://github.com/commercialhaskell/all-cabal-hashes";
+    rev = "5ce8e35ce4a408b2421296307f2a4f1ec232affb";
+
+    outputHashMode = "recursive";
+    outputHashAlgo = "sha256";
+    outputHash = "1albwcvfx2rkrm84llviw1ijx4dknkyq7mahbcipw9ys62700lsq";
+
+    phases = [ "buildPhase" ];
+    nativeBuildInputs = [ git perl ];
+    buildPhase = ''
+      # To reduce overhead we are going to checkout 'display' branch (which have just a few files)
+      git clone --branch display https://github.com/commercialhaskell/all-cabal-hashes.git $out
+
+      cd $out
+      # And now we are checking all the required .cabal files
+      git reset --hard ${rev}
+
+      # .git directory is not reproducible, so we are going to
+      # materialize an explicit mapping from sha1 hash to .cabal file
+      # on top of filesystem. Note that we mention `rev` explicitly
+      # here, so we are always getting a consistent set of objects.
+      git rev-list --objects ${rev} \
+       | git cat-file --batch-check='%(objectname) %(objecttype) %(rest)' \
+       | grep '^[^ ]* blob' \
+       | grep -F .cabal \
+       | awk '{print $1}' \
+       | perl -MFile::Path -nlE 'my($l1, $l2) = m/^(..)(..)/; my $path = "$ENV{out}/_hash-lookup/$l1/$l2"; mkpath $path; system("git cat-file blob $_ > $path/$_")'
+
+      # And now we can get rid of non-deterministic part
+      rm -rf .git
     '';
+
     SSL_CERT_FILE="${cacert}/etc/ssl/certs/ca-bundle.crt";
   };
 


### PR DESCRIPTION
Part of https://github.com/typeable/stackage2nix/issues/41

Initially all-cabal-hashes derivation included a .git directory, which
were used to fetch a .cabal file content given a sha1 hash. The
problem is that there is no canonical representation for .git
directory and every clone is different.

This patch gets rid of .git directory completely. The sha1->content
mapping that was contained here is instead explicitly materialized on
top of a filesystem.

Old derivation already contained several hundred thousands of files,
with this patch this amount approximately trippled. It's not a
significant degradation, but still something that needs to be fixed.

Initially I though about using git .pack/.pack.idx format to store the
mapping, but sadly it won't work for storing mapping from package
name/version to a .cabal-file. Something should be done about
this (put everything into .zip-file? find some other suitable format?
come with a format of our own?). But for now this implementation
should be tolerable (file count "barely" grows from 200k to 500k).