### PR TITLE
fix import purity

### DIFF
--- a/release.nix
+++ b/release.nix
@@ -1,11 +1,13 @@
 { supportedSystems ? [ "x86_64-linux" "i686-linux" ]
 , supportedReleases ? null
-, inHydra ? true }:
+, inHydra ? true
+, pkgs ? import <nixpkgs> {}
+}:
 
 let
-  lib = (import <nixpkgs> {}).lib;
+  inherit (pkgs) lib;
 
-  release = import <nixpkgs/pkgs/top-level/release-lib.nix> {
+  release = import (pkgs.path + "/pkgs/top-level/release-lib.nix") {
     inherit supportedSystems;
     nixpkgsArgs = { overlays = [ (import ./default.nix) ]; };
   };

--- a/stackage/lts-0.0/default.nix
+++ b/stackage/lts-0.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-0.1/default.nix
+++ b/stackage/lts-0.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-0.2/default.nix
+++ b/stackage/lts-0.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-0.3/default.nix
+++ b/stackage/lts-0.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-0.4/default.nix
+++ b/stackage/lts-0.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-0.5/default.nix
+++ b/stackage/lts-0.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-0.6/default.nix
+++ b/stackage/lts-0.6/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-0.7/default.nix
+++ b/stackage/lts-0.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.0/default.nix
+++ b/stackage/lts-1.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.1/default.nix
+++ b/stackage/lts-1.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.10/default.nix
+++ b/stackage/lts-1.10/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.11/default.nix
+++ b/stackage/lts-1.11/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.12/default.nix
+++ b/stackage/lts-1.12/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.13/default.nix
+++ b/stackage/lts-1.13/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.14/default.nix
+++ b/stackage/lts-1.14/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.15/default.nix
+++ b/stackage/lts-1.15/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.2/default.nix
+++ b/stackage/lts-1.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.4/default.nix
+++ b/stackage/lts-1.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.5/default.nix
+++ b/stackage/lts-1.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.7/default.nix
+++ b/stackage/lts-1.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.8/default.nix
+++ b/stackage/lts-1.8/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-1.9/default.nix
+++ b/stackage/lts-1.9/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.0/default.nix
+++ b/stackage/lts-10.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.1/default.nix
+++ b/stackage/lts-10.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.10/default.nix
+++ b/stackage/lts-10.10/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.2/default.nix
+++ b/stackage/lts-10.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.3/default.nix
+++ b/stackage/lts-10.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.4/default.nix
+++ b/stackage/lts-10.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.5/default.nix
+++ b/stackage/lts-10.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.6/default.nix
+++ b/stackage/lts-10.6/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.7/default.nix
+++ b/stackage/lts-10.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.8/default.nix
+++ b/stackage/lts-10.8/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-10.9/default.nix
+++ b/stackage/lts-10.9/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-11.0/default.nix
+++ b/stackage/lts-11.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-11.1/default.nix
+++ b/stackage/lts-11.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-11.2/default.nix
+++ b/stackage/lts-11.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-11.3/default.nix
+++ b/stackage/lts-11.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.0/default.nix
+++ b/stackage/lts-2.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.1/default.nix
+++ b/stackage/lts-2.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.10/default.nix
+++ b/stackage/lts-2.10/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.11/default.nix
+++ b/stackage/lts-2.11/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.12/default.nix
+++ b/stackage/lts-2.12/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.13/default.nix
+++ b/stackage/lts-2.13/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.14/default.nix
+++ b/stackage/lts-2.14/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.15/default.nix
+++ b/stackage/lts-2.15/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.16/default.nix
+++ b/stackage/lts-2.16/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.17/default.nix
+++ b/stackage/lts-2.17/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.18/default.nix
+++ b/stackage/lts-2.18/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.19/default.nix
+++ b/stackage/lts-2.19/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.2/default.nix
+++ b/stackage/lts-2.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.20/default.nix
+++ b/stackage/lts-2.20/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.21/default.nix
+++ b/stackage/lts-2.21/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.22/default.nix
+++ b/stackage/lts-2.22/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.3/default.nix
+++ b/stackage/lts-2.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.4/default.nix
+++ b/stackage/lts-2.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.5/default.nix
+++ b/stackage/lts-2.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.6/default.nix
+++ b/stackage/lts-2.6/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.7/default.nix
+++ b/stackage/lts-2.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.8/default.nix
+++ b/stackage/lts-2.8/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-2.9/default.nix
+++ b/stackage/lts-2.9/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.0/default.nix
+++ b/stackage/lts-3.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.1/default.nix
+++ b/stackage/lts-3.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.10/default.nix
+++ b/stackage/lts-3.10/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.11/default.nix
+++ b/stackage/lts-3.11/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.12/default.nix
+++ b/stackage/lts-3.12/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.13/default.nix
+++ b/stackage/lts-3.13/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.14/default.nix
+++ b/stackage/lts-3.14/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.15/default.nix
+++ b/stackage/lts-3.15/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.16/default.nix
+++ b/stackage/lts-3.16/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.17/default.nix
+++ b/stackage/lts-3.17/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.18/default.nix
+++ b/stackage/lts-3.18/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.19/default.nix
+++ b/stackage/lts-3.19/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.2/default.nix
+++ b/stackage/lts-3.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.20/default.nix
+++ b/stackage/lts-3.20/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.21/default.nix
+++ b/stackage/lts-3.21/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.22/default.nix
+++ b/stackage/lts-3.22/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.3/default.nix
+++ b/stackage/lts-3.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.4/default.nix
+++ b/stackage/lts-3.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.5/default.nix
+++ b/stackage/lts-3.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.6/default.nix
+++ b/stackage/lts-3.6/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.7/default.nix
+++ b/stackage/lts-3.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.8/default.nix
+++ b/stackage/lts-3.8/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-3.9/default.nix
+++ b/stackage/lts-3.9/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-4.0/default.nix
+++ b/stackage/lts-4.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-4.1/default.nix
+++ b/stackage/lts-4.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-4.2/default.nix
+++ b/stackage/lts-4.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.0/default.nix
+++ b/stackage/lts-5.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.1/default.nix
+++ b/stackage/lts-5.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.10/default.nix
+++ b/stackage/lts-5.10/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.11/default.nix
+++ b/stackage/lts-5.11/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.12/default.nix
+++ b/stackage/lts-5.12/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.13/default.nix
+++ b/stackage/lts-5.13/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.14/default.nix
+++ b/stackage/lts-5.14/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.15/default.nix
+++ b/stackage/lts-5.15/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.16/default.nix
+++ b/stackage/lts-5.16/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.17/default.nix
+++ b/stackage/lts-5.17/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.18/default.nix
+++ b/stackage/lts-5.18/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.2/default.nix
+++ b/stackage/lts-5.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.3/default.nix
+++ b/stackage/lts-5.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.4/default.nix
+++ b/stackage/lts-5.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.5/default.nix
+++ b/stackage/lts-5.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.6/default.nix
+++ b/stackage/lts-5.6/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.7/default.nix
+++ b/stackage/lts-5.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.8/default.nix
+++ b/stackage/lts-5.8/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-5.9/default.nix
+++ b/stackage/lts-5.9/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.0/default.nix
+++ b/stackage/lts-6.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.1/default.nix
+++ b/stackage/lts-6.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.10/default.nix
+++ b/stackage/lts-6.10/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.11/default.nix
+++ b/stackage/lts-6.11/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.12/default.nix
+++ b/stackage/lts-6.12/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.13/default.nix
+++ b/stackage/lts-6.13/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.14/default.nix
+++ b/stackage/lts-6.14/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.15/default.nix
+++ b/stackage/lts-6.15/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.16/default.nix
+++ b/stackage/lts-6.16/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.17/default.nix
+++ b/stackage/lts-6.17/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.18/default.nix
+++ b/stackage/lts-6.18/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.19/default.nix
+++ b/stackage/lts-6.19/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.2/default.nix
+++ b/stackage/lts-6.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.20/default.nix
+++ b/stackage/lts-6.20/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.21/default.nix
+++ b/stackage/lts-6.21/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.22/default.nix
+++ b/stackage/lts-6.22/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.23/default.nix
+++ b/stackage/lts-6.23/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.24/default.nix
+++ b/stackage/lts-6.24/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.25/default.nix
+++ b/stackage/lts-6.25/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.26/default.nix
+++ b/stackage/lts-6.26/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.27/default.nix
+++ b/stackage/lts-6.27/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.28/default.nix
+++ b/stackage/lts-6.28/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.29/default.nix
+++ b/stackage/lts-6.29/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.3/default.nix
+++ b/stackage/lts-6.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.30/default.nix
+++ b/stackage/lts-6.30/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.31/default.nix
+++ b/stackage/lts-6.31/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.32/default.nix
+++ b/stackage/lts-6.32/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.33/default.nix
+++ b/stackage/lts-6.33/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.34/default.nix
+++ b/stackage/lts-6.34/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.35/default.nix
+++ b/stackage/lts-6.35/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.4/default.nix
+++ b/stackage/lts-6.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.5/default.nix
+++ b/stackage/lts-6.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.6/default.nix
+++ b/stackage/lts-6.6/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.7/default.nix
+++ b/stackage/lts-6.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.8/default.nix
+++ b/stackage/lts-6.8/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-6.9/default.nix
+++ b/stackage/lts-6.9/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.0/default.nix
+++ b/stackage/lts-7.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.1/default.nix
+++ b/stackage/lts-7.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.10/default.nix
+++ b/stackage/lts-7.10/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.11/default.nix
+++ b/stackage/lts-7.11/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.12/default.nix
+++ b/stackage/lts-7.12/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.13/default.nix
+++ b/stackage/lts-7.13/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.14/default.nix
+++ b/stackage/lts-7.14/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.15/default.nix
+++ b/stackage/lts-7.15/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.16/default.nix
+++ b/stackage/lts-7.16/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.17/default.nix
+++ b/stackage/lts-7.17/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.18/default.nix
+++ b/stackage/lts-7.18/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.19/default.nix
+++ b/stackage/lts-7.19/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.2/default.nix
+++ b/stackage/lts-7.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.20/default.nix
+++ b/stackage/lts-7.20/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.21/default.nix
+++ b/stackage/lts-7.21/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.22/default.nix
+++ b/stackage/lts-7.22/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.23/default.nix
+++ b/stackage/lts-7.23/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.24/default.nix
+++ b/stackage/lts-7.24/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.3/default.nix
+++ b/stackage/lts-7.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.4/default.nix
+++ b/stackage/lts-7.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.5/default.nix
+++ b/stackage/lts-7.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.6/default.nix
+++ b/stackage/lts-7.6/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.7/default.nix
+++ b/stackage/lts-7.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.8/default.nix
+++ b/stackage/lts-7.8/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-7.9/default.nix
+++ b/stackage/lts-7.9/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.0/default.nix
+++ b/stackage/lts-8.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.1/default.nix
+++ b/stackage/lts-8.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.10/default.nix
+++ b/stackage/lts-8.10/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.11/default.nix
+++ b/stackage/lts-8.11/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.12/default.nix
+++ b/stackage/lts-8.12/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.13/default.nix
+++ b/stackage/lts-8.13/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.14/default.nix
+++ b/stackage/lts-8.14/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.15/default.nix
+++ b/stackage/lts-8.15/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.16/default.nix
+++ b/stackage/lts-8.16/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.17/default.nix
+++ b/stackage/lts-8.17/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.18/default.nix
+++ b/stackage/lts-8.18/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.19/default.nix
+++ b/stackage/lts-8.19/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.2/default.nix
+++ b/stackage/lts-8.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.20/default.nix
+++ b/stackage/lts-8.20/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.21/default.nix
+++ b/stackage/lts-8.21/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.22/default.nix
+++ b/stackage/lts-8.22/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.23/default.nix
+++ b/stackage/lts-8.23/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.24/default.nix
+++ b/stackage/lts-8.24/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.3/default.nix
+++ b/stackage/lts-8.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.4/default.nix
+++ b/stackage/lts-8.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.5/default.nix
+++ b/stackage/lts-8.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.6/default.nix
+++ b/stackage/lts-8.6/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.7/default.nix
+++ b/stackage/lts-8.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.8/default.nix
+++ b/stackage/lts-8.8/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-8.9/default.nix
+++ b/stackage/lts-8.9/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.0/default.nix
+++ b/stackage/lts-9.0/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.1/default.nix
+++ b/stackage/lts-9.1/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.10/default.nix
+++ b/stackage/lts-9.10/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.11/default.nix
+++ b/stackage/lts-9.11/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.12/default.nix
+++ b/stackage/lts-9.12/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.13/default.nix
+++ b/stackage/lts-9.13/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.14/default.nix
+++ b/stackage/lts-9.14/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.15/default.nix
+++ b/stackage/lts-9.15/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.16/default.nix
+++ b/stackage/lts-9.16/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.17/default.nix
+++ b/stackage/lts-9.17/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.18/default.nix
+++ b/stackage/lts-9.18/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.19/default.nix
+++ b/stackage/lts-9.19/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.2/default.nix
+++ b/stackage/lts-9.2/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.20/default.nix
+++ b/stackage/lts-9.20/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.21/default.nix
+++ b/stackage/lts-9.21/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.3/default.nix
+++ b/stackage/lts-9.3/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.4/default.nix
+++ b/stackage/lts-9.4/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.5/default.nix
+++ b/stackage/lts-9.5/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.6/default.nix
+++ b/stackage/lts-9.6/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.7/default.nix
+++ b/stackage/lts-9.7/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.8/default.nix
+++ b/stackage/lts-9.8/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 

--- a/stackage/lts-9.9/default.nix
+++ b/stackage/lts-9.9/default.nix
@@ -19,7 +19,7 @@ let
   compilerConfig = import  ./configuration-packages.nix { inherit pkgs haskellLib; };
   
   configurationCommon = if builtins.pathExists ./configuration-common.nix then import ./configuration-common.nix { inherit pkgs haskellLib; } else self: super: {};
-  configurationNix = import <nixpkgs/pkgs/development/haskell-modules/configuration-nix.nix> { inherit pkgs haskellLib; };
+  configurationNix = import (pkgs.path + "/pkgs/development/haskell-modules/configuration-nix.nix") { inherit pkgs haskellLib; };
   
   extensible-self = makeExtensible (extends overrides (extends configurationCommon (extends packageSetConfig (extends compilerConfig (extends configurationNix haskellPackages)))));
 


### PR DESCRIPTION
avoid depending on NIX_PATH, it makes it hard to pin the nixpkgs version

    rg '<nixpkgs/' | cat | cut -d ':' -f 1 | xargs -n1 -- sed -e 's|<nixpkgs/\(.*\)>|(pkgs.path + "/\1")|g' -i


Related to https://github.com/typeable/stackage2nix/pull/54